### PR TITLE
Extract current target triple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-extract"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-extract"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Emil Englesson <englesson.emil@gmail.com>"]
 description = "Cargo subcommand to extract information from Cargo.toml files"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ cargo extract package.name
 cargo-extract
 
 $ cargo extract package.version
-0.2.0
+0.3.0
 
 $ cargo extract package.categories
 command-line-utilities

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let name = "TARGET_TRIPLE";
+    let value = std::env::var("TARGET").unwrap();
+
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rustc-env={name}={value}");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,53 @@
 use cargo_extract::ExtractResult;
-use clap::{crate_version, Arg, Command};
+use clap::{crate_version, Arg, ArgAction, ArgGroup, Command};
 use std::{fs, process};
 
 fn main() {
     let access_pattern_arg = "access_pattern";
+    let architecture_arg = "architecture";
     let matches = Command::new("cargo")
         .bin_name("cargo")
         .version(crate_version!())
         .long_version(crate_version!())
         .about("Extracts information found in Cargo.toml")
         .subcommand_required(true)
-        .subcommand(Command::new("extract").arg(Arg::new(access_pattern_arg).required(true)))
+        .subcommand(
+            Command::new("extract")
+                .arg(
+                    Arg::new(architecture_arg)
+                        .long("arch")
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(Arg::new(access_pattern_arg))
+                .group(
+                    ArgGroup::new("input")
+                        .required(true)
+                        .args([access_pattern_arg, architecture_arg]),
+                ),
+        )
         .get_matches();
 
     let Some(("extract", matches)) = matches.subcommand() else {
         unreachable!()
     };
 
-    let pattern = matches
-        .get_one::<String>(access_pattern_arg)
-        .expect("Argument required");
+    let pattern = matches.get_one::<String>(access_pattern_arg);
+    let arch_flag = matches.get_one::<bool>(architecture_arg);
 
+    if let Some(pattern) = pattern {
+        handle_pattern(pattern);
+    } else if arch_flag.is_some() {
+        handle_arch();
+    } else {
+        process::exit(1);
+    }
+}
+
+fn handle_pattern(pattern: &str) {
     let manifest = read_cargo_toml().expect("Failed to find Cargo.toml");
     let manifest = manifest
         .parse::<toml::Value>()
         .expect("Failed to parse Cargo.toml manifest");
-
     match cargo_extract::extract(pattern, manifest) {
         Ok(extracted) => println!("{extracted}"),
         Err(err) => {
@@ -33,6 +55,10 @@ fn main() {
             process::exit(1);
         }
     }
+}
+
+fn handle_arch() {
+    println!("{}", env!("TARGET_TRIPLE"));
 }
 
 pub fn read_cargo_toml() -> ExtractResult<String> {


### PR DESCRIPTION
Added a flag `--arch` that is mutually exclusive with the normal usage of the command. Using that flag will print the current target triple.